### PR TITLE
fix: cocli list all

### DIFF
--- a/docs/developers/cocli/3-cli-action-operations.md
+++ b/docs/developers/cocli/3-cli-action-operations.md
@@ -73,8 +73,8 @@ fb1bb37a-7b27-11ee-b962-0242ac120002     system      ros2-mcap-converter        
 
 ```bash
 # 使用 JSON 输出获取记录和动作, 比如要在第一个记录中执行 coScene-test 动作
-RECORD_NAME=$(cocli record list -o json | jq -r '.records[0].name')
-ACTION_NAME=$(cocli action list -o json | jq -r '.actions[] | select(.spec.name | contains("coScene-test")) | .name')
+RECORD_NAME=$(cocli record list --page-size 10 -o json | jq -r '.records[0].name')
+ACTION_NAME=$(cocli action list --all -o json | jq -r '.actions[] | select(.spec.name | contains("coScene-test")) | .name')
 cocli action run $ACTION_NAME $RECORD_NAME
 ```
 

--- a/docs/developers/cocli/97-cli-common-batch-tasks.md
+++ b/docs/developers/cocli/97-cli-common-batch-tasks.md
@@ -17,7 +17,7 @@ sidebar_position: 4
 
 ```bash
 # 使用 JSON 输出和 jq 提取记录 ID
-cocli record list -o json | jq -r '.records[].name' | \
+cocli record list --all -o json | jq -r '.records[].name' | \
   xargs -I {} cocli record upload {} ./FILE_FLAG
 ```
 
@@ -52,7 +52,7 @@ done
 
 ```bash
 # 使用 JSON 输出获取项目中的所有记录，遍历并提供记录的完整资源名称
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # 使用 $record_name 进行后续的批量操作
     # 如需提取 record ID，可以使用: record_id=$(basename "$record_name")
 done
@@ -63,7 +63,7 @@ done
 ### 找出所有不含任何文件的空记录
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # 获取记录中的文件数量
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 
@@ -79,7 +79,7 @@ done
 ### 给所有空记录打上标签
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # 获取记录中的文件数量
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 
@@ -95,7 +95,7 @@ done
 
 ```bash
 # 使用 --labels 参数过滤特定标签的记录
-cocli record list --labels test-label -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --labels test-label --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # 下载所有有 test-label 标签的记录
     cocli record download "$record_name" download-folder
 done
@@ -108,7 +108,7 @@ done
 :::
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # 获取记录中的文件数量
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/developers/cocli/3-cli-action-operations.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/developers/cocli/3-cli-action-operations.md
@@ -73,7 +73,7 @@ Using JSON output with the `jq` tool to extract IDs is more reliable and stable.
 ```bash
 # Use JSON output to get record and action, e.g., to run the coScene-test action on the first record
 RECORD_NAME=$(cocli record list -o json | jq -r '.records[0].name')
-ACTION_NAME=$(cocli action list -o json | jq -r '.actions[] | select(.spec.name | contains("coScene-test")) | .name')
+ACTION_NAME=$(cocli action list --all -o json | jq -r '.actions[] | select(.spec.name | contains("coScene-test")) | .name')
 cocli action run $ACTION_NAME $RECORD_NAME
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/developers/cocli/97-cli-common-batch-tasks.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/developers/cocli/97-cli-common-batch-tasks.md
@@ -17,7 +17,7 @@ If your system doesn't have `jq` installed, you can install it with the followin
 
 ```bash
 # Use JSON output and jq to extract record names
-cocli record list -o json | jq -r '.records[].name' | \
+cocli record list --all -o json | jq -r '.records[].name' | \
   xargs -I {} cocli record upload {} ./FILE_FLAG
 ```
 
@@ -50,7 +50,7 @@ A common command line operation pattern is to iterate through all records in a u
 
 ```bash
 # Use JSON output to get all records in the project, iterate and provide the full resource name
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # Use $record_name for subsequent batch operations
     # To extract record ID, you can use: record_id=$(basename "$record_name")
 done
@@ -61,7 +61,7 @@ This pattern can be extended to connect more complex batch operations.
 ### Find All Empty Records Without Any Files
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # Get the number of files in the record
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 
@@ -77,7 +77,7 @@ done
 ### Tag All Empty Records
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # Get the number of files in the record
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 
@@ -93,7 +93,7 @@ done
 
 ```bash
 # Use --labels parameter to filter records with specific labels
-cocli record list --labels test-label -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --labels test-label --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # Download all records with test-label
     cocli record download "$record_name" download-folder
 done
@@ -106,7 +106,7 @@ Please be very careful with the `delete` operation, as it may delete important d
 :::
 
 ```bash
-cocli record list -o json | jq -r '.records[].name' | while read -r record_name; do
+cocli record list --all -o json | jq -r '.records[].name' | while read -r record_name; do
     # Get the number of files in the record
     file_count=$(cocli record file list "$record_name" -o json 2>/dev/null | jq '.files | length')
 


### PR DESCRIPTION
We need to use the `--all` option to list all records.