### PR TITLE
fix(automation): correct parameter template syntax in action-overview

### DIFF
--- a/docs/6-automation/2-action-overview.md
+++ b/docs/6-automation/2-action-overview.md
@@ -27,9 +27,9 @@ sidebar_position: 1
 
 ![action-overview_3](./img/action-overview_3.png)
 
-参数包含 Key 和 Value，在步骤的命令中可使用 `{{parameter.key}}` 引用参数。
+参数包含 Key 和 Value，在步骤的命令中可使用 `{{parameters.key}}` 引用参数。
 
-例如：Key 为 `input`，Value 为 `hello world`，则在步骤的命令中可使用 `{{parameter.input}}` 引用参数。
+例如：Key 为 `input`，Value 为 `hello world`，则在步骤的命令中可使用 `{{parameters.input}}` 引用参数。
 
 ## 步骤类型及信息
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/6-automation/2-action-overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/6-automation/2-action-overview.md
@@ -28,9 +28,9 @@ Actions are the fundamental building blocks of automated workflows, representing
 
 ![action-overview_3](./img/action-overview_3.png)
 
-Parameters consist of a Key and a Value. You can reference parameters in step commands using `{{parameter.key}}`.
+Parameters consist of a Key and a Value. You can reference parameters in step commands using `{{parameters.key}}`.
 
-For example, if the Key is `input` and the Value is `hello world`, you can reference the parameter in a step command using `{{parameter.input}}`.
+For example, if the Key is `input` and the Value is `hello world`, you can reference the parameter in a step command using `{{parameters.input}}`.
 
 ## Step Types and Information
 


### PR DESCRIPTION
## 问题

动作参数文档中文本 `{{parameter.key}}` 写成了单数，与截图不符（截图为复数 `{{parameters.key}}`）。

- 页面：https://docs.coscene.cn/docs/automation/action-overview （中文）
- 英文：https://docs.coscene.cn/en/docs/automation/action-overview

## 修复

将 `{{parameter.key}}` / `{{parameter.input}}` 改为复数 `{{parameters.key}}` / `{{parameters.input}}`，与 `3-create-action.md` 中已有的 `{{parameters.filename}}` 用法保持一致。

## 改动文件

- `docs/6-automation/2-action-overview.md`（中文，2 处）
- `i18n/en/docusaurus-plugin-content-docs/current/6-automation/2-action-overview.md`（英文，2 处）

已全仓扫描，其余 `parameter.` 命中（viz 扩展文档的 ExtensionContext / ParameterValue）为不相关术语，无同类错误。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/docs/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785300352&installation_id=141984720&pr_number=383&repository=coscene-io%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fdocs%2Fpull%2F383&signature=8ba10a8ea2358257786aa0473e4bc39c3a364663e2ccb4a5e139377f3d8080e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->