### PR TITLE
CI: pr-check.yml 迁到 cos-m 自建 runner

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   quick-ci-check:
-    runs-on: ubuntu-latest
+    runs-on: cos-m
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
## 做了什么

`pr-check.yml` 的 `runs-on` 换成 `cos-m`(自建 runner 池)。 只动 `pr-check.yml`;`deploy-to-*` 属于 CD,本 PR 不碰。

## 证据

已在自建 runner 上真跑通过:[run 33194719933](https://github.com/coscene-io/docs/actions/runs/33194719933),落在 `cos-ci-1-d`,用时 48s。

逐 job 核实过 `runner_name` / `labels` 确实是自建池,并核实每个 step 都真的执行了(被 skip 的 step 不算通过)。

## 风险

`runs-on` 是逐 workflow 的,本 PR 只动这一个文件。自建池已有多个仓库的 CI 在上面跑。出问题把这一行改回去即可。
